### PR TITLE
CI: Run type checking for lambda funcitons

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,3 +30,6 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npx sst build --stage prod
+    - name: Typecheck lambda functions
+      run: npm run typecheck
+      working-directory: ./packages/functions

--- a/.github/workflows/deploy-on-push-main.yaml
+++ b/.github/workflows/deploy-on-push-main.yaml
@@ -31,3 +31,6 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npx sst deploy --stage prod
+    - name: Typecheck lambda functions
+      run: npm run typecheck
+      working-directory: ./packages/functions


### PR DESCRIPTION
During our time at CIC, the front-end failed on type errors, but not the backend.

I added this to our project to catch errors before they're pushed to main, and thought to share, it might be useful for next batches.